### PR TITLE
Rigidbody Velocity Gizmo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - ComponentGizmo base class that automatically attaches a gizmo to another component
  - BehaviourGizmo base class that draws its gizmo conditionally based on the enabled state of an attached behaviour
  - TriggerGizmo class that tracks the colliders entering and exiting a trigger
+ - RigidbodyVelocityGizmo class that visualises the angular and linear velocity of an attached Rigidbody

--- a/Runtime/Physics/RigidbodyVelocityGizmo.cs
+++ b/Runtime/Physics/RigidbodyVelocityGizmo.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+
+namespace dGameBoy101b.CustomisableGizmos
+{
+	/**
+	 * A gizmo that attaches to a rigidbody and visualises its angular and linear velocity
+	 * @author dGameBoy101b
+	 * @date 2022-12-23
+	 */
+	[AddComponentMenu("Customisable Gizmos/Physics/Rigidbody Velocity Gizmo")]
+	public class RigidbodyVelocityGizmo : ComponentGizmo<Rigidbody>
+	{
+		[SerializeField]
+		[Tooltip("The colour used to draw the linear velocity of the attached rigidbody")]
+		private Color _linearVelocityColour = Color.yellow;
+
+		/**
+		 * The colour used to draw the linear velocity of the attached rigidbody
+		 */
+		public Color LinearVelocityColour
+		{
+			get => this._linearVelocityColour;
+			set => this._linearVelocityColour = value;
+		}
+
+		[SerializeField]
+		[Tooltip("The colour used to draw the angular velocity of the attached rigidbody")]
+		private Color _angularVelocityColour = Color.cyan;
+
+		/**
+		 * The colour used to draw the angular velocity of the attached rigidbody
+		 */
+		public Color AngularVelocityColour
+		{
+			get => this._angularVelocityColour;
+			set => this._angularVelocityColour = value;
+		}
+
+		protected override void Draw()
+		{
+			Vector3 center = this.Source.centerOfMass + this.Source.transform.position;
+			Gizmos.color = this.LinearVelocityColour;
+			Gizmos.DrawRay(center, this.Source.velocity);
+			Gizmos.color = this.AngularVelocityColour;
+			Gizmos.DrawRay(center, this.Source.angularVelocity);
+		}
+	}
+}

--- a/Runtime/Physics/RigidbodyVelocityGizmo.cs
+++ b/Runtime/Physics/RigidbodyVelocityGizmo.cs
@@ -7,9 +7,11 @@ namespace dGameBoy101b.CustomisableGizmos
 	 * @author dGameBoy101b
 	 * @date 2022-12-23
 	 */
-	[AddComponentMenu("Customisable Gizmos/Physics/Rigidbody Velocity Gizmo")]
+	[AddComponentMenu("Customisable Gizmo/Physics/Rigidbody Velocity Gizmo")]
 	public class RigidbodyVelocityGizmo : ComponentGizmo<Rigidbody>
 	{
+		[Header("Linear Velocity")]
+
 		[SerializeField]
 		[Tooltip("The colour used to draw the linear velocity of the attached rigidbody")]
 		private Color _linearVelocityColour = Color.yellow;
@@ -24,6 +26,21 @@ namespace dGameBoy101b.CustomisableGizmos
 		}
 
 		[SerializeField]
+		[Tooltip("Scaling applied to the linear velocity ray")]
+		private float _linearVelocityScale = 1f;
+
+		/**
+		 * Scaling applied to the linear velocity ray
+		 */
+		public float LinearVelocityScale
+		{
+			get => this._linearVelocityScale;
+			set => this._linearVelocityScale = value;
+		}
+
+		[Header("Angular Velocity")]
+
+		[SerializeField]
 		[Tooltip("The colour used to draw the angular velocity of the attached rigidbody")]
 		private Color _angularVelocityColour = Color.cyan;
 
@@ -36,13 +53,26 @@ namespace dGameBoy101b.CustomisableGizmos
 			set => this._angularVelocityColour = value;
 		}
 
+		[SerializeField]
+		[Tooltip("Scaling applied to the angular velocity ray")]
+		private float _angularVelocityScale = 1f;
+
+		/**
+		 * Scaling applied to the angular velocity ray
+		 */
+		public float AngularVelocityScale
+		{
+			get => this._angularVelocityScale;
+			set => this._angularVelocityScale = value;
+		}
+
 		protected override void Draw()
 		{
 			Vector3 center = this.Source.centerOfMass + this.Source.transform.position;
 			Gizmos.color = this.LinearVelocityColour;
-			Gizmos.DrawRay(center, this.Source.velocity);
+			Gizmos.DrawRay(center, this.Source.velocity * this.LinearVelocityScale);
 			Gizmos.color = this.AngularVelocityColour;
-			Gizmos.DrawRay(center, this.Source.angularVelocity);
+			Gizmos.DrawRay(center, this.Source.angularVelocity * this.AngularVelocityScale);
 		}
 	}
 }

--- a/Runtime/Physics/RigidbodyVelocityGizmo.cs.meta
+++ b/Runtime/Physics/RigidbodyVelocityGizmo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 95210079b05e150488aef7cf64f0a8b3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Created a new gizmo which visualises the linear and angular velocity of a Rigidbody: the Rigidbody Velocity Gizmo.
Includes settings for the colour and scaling of the two rays, which originate from the center of mass, used to visualise these independent velocities. 